### PR TITLE
enable vector operation for ieee, vprec and mca backends

### DIFF
--- a/src/backends/interflop-mca/Makefile.am
+++ b/src/backends/interflop-mca/Makefile.am
@@ -4,6 +4,7 @@ libinterflop_mca_la_CFLAGS = -DBACKEND_HEADER="interflop_mca"
 if WALL_CFLAGS
 libinterflop_mca_la_CFLAGS += -Wall -Wextra
 endif
+libinterflop_mca_la_CFLAGS += -march=native
 libinterflop_mca_la_LDFLAGS = -lm
 libinterflop_mca_la_LIBADD = ../../common/libtinymt64.la
 library_includedir =$(includedir)/

--- a/src/backends/interflop-vprec/Makefile.am
+++ b/src/backends/interflop-vprec/Makefile.am
@@ -4,6 +4,7 @@ libinterflop_vprec_la_CFLAGS = -DBACKEND_HEADER="interflop_vprec"
 if WALL_CFLAGS
 libinterflop_vprec_la_CFLAGS += -Wall -Wextra -Wno-varargs
 endif
+libinterflop_vprec_la_CFLAGS += -march=native
 libinterflop_vprec_la_LDFLAGS = -lm
 libinterflop_vprec_la_LIBADD = ../../common/libvprec_tools.la ../../common/libvfc_hashmap.la
 library_includedir =$(includedir)/

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -131,7 +131,7 @@ def linker_mode(sources, options, output, args):
     extra_args += "-DDDEBUG " if args.ddebug else ""
     extra_args += "-DINST_FUNC " if args.inst_func else ""
 
-    shell('{clang} -c -O3 -Wno-varargs {extra_args} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
+    shell('{clang} -c -O3 -march=native -Wno-varargs {extra_args} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
         extra_args=extra_args,
         vfcwrapper=vfcwrapper,


### PR DESCRIPTION
- add -march=native to enable automaticaly the higher vector size
- compile wrapper with -march=native
- compile cited backends with -march=native